### PR TITLE
New `partition_offsets` module metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,9 +348,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -941,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.34.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053adfa02fab06e86c01d586cc68aa47ee0ff4489a59469081dc12cbcde578bf"
+checksum = "d54f02a5a40220f8a2dfa47ddb38ba9064475a5807a69504b6f91711df2eea63"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "rdkafka-sys"
-version = "4.6.0+2.2.0"
+version = "4.7.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad63c279fca41a27c231c450a2d2ad18288032e9cbb159ad16c9d96eba35aaaf"
+checksum = "55e0d2f9ba6253f6ec72385e453294f8618e9e15c2c6aba2a5c01ccf9622d615"
 dependencies = [
  "libc",
  "libz-sys",
@@ -1061,18 +1061,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.190"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1.33.0", features = ["rt", "rt-multi-thread", "time", "sync
 tokio-util = "0.7.10"
 
 [target.'cfg(unix)'.dependencies]
-rdkafka = { version = "0.34.0", features = ["ssl-vendored", "gssapi-vendored", "libz-static"] }
+rdkafka = { version = "0.36.0", features = ["ssl-vendored", "gssapi-vendored", "libz-static"] }
 
 [profile.release]
 strip = true # Automatically strip symbols from the binary.

--- a/METRICS.md
+++ b/METRICS.md
@@ -99,7 +99,7 @@ to produce the lag information for).
     <b>Description:</b> <i>"Consumer groups currently in the cluster.</i><br/>
     <b>Labels:</b> <code>cluster_id</code><br/>
     <b>Type:</b> <code>gauge</code><br/>
-    <b>Timestamped:</b> <code>true</code>
+    <b>Timestamped:</b> <code>false</code>
   </dd>
 </dl>
 
@@ -109,7 +109,7 @@ to produce the lag information for).
     <b>Description:</b> <i>Members of consumer groups currently in the cluster.</i><br/>
     <b>Labels:</b> <code>cluster_id, group</code><br/>
     <b>Type:</b> <code>gauge</code><br/>
-    <b>Timestamped:</b> <code>true</code>
+    <b>Timestamped:</b> <code>false</code>
   </dd>
 </dl>
 
@@ -118,10 +118,10 @@ to produce the lag information for).
 <dl>
   <dt><code>kmtd_consumer_groups_emitter_fetch_time_milliseconds</code></dt>
   <dd>
-    <b>Description:</b> <i>Time (in milliseconds) taken to fetch information about all consumer groups in cluster.</i><br/>
+    <b>Description:</b> <i>Time (ms) taken to fetch information about all consumer groups in cluster.</i><br/>
     <b>Labels:</b> <code>cluster_id</code><br/>
     <b>Type:</b> <code>histogram</code><br/>
-    <b>Timestamped:</b> <code>true</code>
+    <b>Timestamped:</b> <code>false</code>
   </dd>
 </dl>
 
@@ -131,7 +131,27 @@ to produce the lag information for).
     <b>Description:</b> <i>Capacity of internal channel used to send consumer groups metadata to rest of the service.</i><br/>
     <b>Labels:</b> <code>cluster_id</code><br/>
     <b>Type:</b> <code>gauge</code><br/>
-    <b>Timestamped:</b> <code>true</code>
+    <b>Timestamped:</b> <code>false</code>
+  </dd>
+</dl>
+
+<dl>
+  <dt><code>kmtd_partition_offsets_emitter_fetch_time_milliseconds</code></dt>
+  <dd>
+    <b>Description:</b> <i>Time (ms) taken to fetch earliest/latest (watermark) offsets of a specific topic partition in cluster.</i><br/>
+    <b>Labels:</b> <code>cluster_id, topic, partition</code><br/>
+    <b>Type:</b> <code>histogram</code><br/>
+    <b>Timestamped:</b> <code>false</code>
+  </dd>
+</dl>
+
+<dl>
+  <dt><code>kmtd_partition_offsets_emitter_channel_capacity</code></dt>
+  <dd>
+    <b>Description:</b> <i>Capacity of internal channel used to send partition watermark offsets to rest of the service.</i><br/>
+    <b>Labels:</b> <code>cluster_id</code><br/>
+    <b>Type:</b> <code>gauge</code><br/>
+    <b>Timestamped:</b> <code>false</code>
   </dd>
 </dl>
 

--- a/METRICS.md
+++ b/METRICS.md
@@ -155,6 +155,16 @@ to produce the lag information for).
   </dd>
 </dl>
 
+<dl>
+  <dt><code>kmtd_partition_offsets_register_usage</code></dt>
+  <dd>
+    <b>Description:</b> <i>Amount of offsets tracked per topic partition.</i><br/>
+    <b>Labels:</b> <code>cluster_id, topic, partition</code><br/>
+    <b>Type:</b> <code>gauge</code><br/>
+    <b>Timestamped:</b> <code>false</code>
+  </dd>
+</dl>
+
 ## Labels
 
 Each metrics has some or all of the following labels applied; what labels applies

--- a/src/consumer_groups/emitter.rs
+++ b/src/consumer_groups/emitter.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use const_format::formatcp;
 use konsumer_offsets::ConsumerProtocolAssignment;
 use prometheus::{
     register_histogram_with_registry, register_int_gauge_vec_with_registry,
@@ -21,22 +20,21 @@ use tokio_util::sync::CancellationToken;
 use crate::constants::KOMMITTED_CONSUMER_OFFSETS_CONSUMER;
 use crate::internals::Emitter;
 use crate::kafka_types::{Group, GroupWithMembers, Member, MemberWithAssignment, TopicPartition};
-use crate::prometheus_metrics::{LABEL_GROUP, NAMESPACE};
+use crate::prometheus_metrics::LABEL_GROUP;
 
 const CHANNEL_SIZE: usize = 5;
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 const FETCH_INTERVAL: Duration = Duration::from_secs(60);
 
-const MET_TOT_NAME: &str = formatcp!("{NAMESPACE}_consumer_groups_total");
+const MET_TOT_NAME: &str = "consumer_groups_total";
 const MET_TOT_HELP: &str = "Consumer groups currently in the cluster";
-const MET_MEMBERS_TOT_NAME: &str = formatcp!("{NAMESPACE}_consumer_groups_members_total");
+const MET_MEMBERS_TOT_NAME: &str = "consumer_groups_members_total";
 const MET_MEMBERS_TOT_HELP: &str = "Members of consumer groups currently in the cluster";
-const MET_FETCH_NAME: &str =
-    formatcp!("{NAMESPACE}_consumer_groups_emitter_fetch_time_milliseconds");
+const MET_FETCH_NAME: &str = "consumer_groups_emitter_fetch_time_milliseconds";
 const MET_FETCH_HELP: &str =
     "Time (ms) taken to fetch information about all consumer groups in cluster";
-const MET_CH_CAP_NAME: &str = formatcp!("{NAMESPACE}_consumer_groups_emitter_channel_capacity");
+const MET_CH_CAP_NAME: &str = "consumer_groups_emitter_channel_capacity";
 const MET_CH_CAP_HELP: &str =
     "Capacity of internal channel used to send consumer groups metadata to rest of the service";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         cli.offsets_history_ready_at,
         cs_reg_arc.clone(),
         shutdown_token.clone(),
+        prom_reg_arc.clone(),
     );
     po_reg.await_ready(shutdown_token.clone()).await?;
     let po_reg_arc = Arc::new(po_reg);

--- a/src/partition_offsets/emitter.rs
+++ b/src/partition_offsets/emitter.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use const_format::formatcp;
 use prometheus::{
     register_histogram_vec_with_registry, register_int_gauge_with_registry, HistogramVec, IntGauge,
     Registry,
@@ -17,18 +16,17 @@ use tokio_util::sync::CancellationToken;
 
 use crate::cluster_status::ClusterStatusRegister;
 use crate::internals::Emitter;
-use crate::prometheus_metrics::{LABEL_PARTITION, LABEL_TOPIC, NAMESPACE};
+use crate::prometheus_metrics::{LABEL_PARTITION, LABEL_TOPIC};
 
 const CHANNEL_SIZE: usize = 10_000;
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 const FETCH_INTERVAL: Duration = Duration::from_millis(10);
 
-const MET_FETCH_NAME: &str =
-    formatcp!("{NAMESPACE}_partition_offsets_emitter_fetch_time_milliseconds");
+const MET_FETCH_NAME: &str = "_partition_offsets_emitter_fetch_time_milliseconds";
 const MET_FETCH_HELP: &str =
     "Time (ms) taken to fetch earliest/latest (watermark) offsets of a specific topic partition in cluster";
-const MET_CH_CAP_NAME: &str = formatcp!("{NAMESPACE}_partition_offsets_emitter_channel_capacity");
+const MET_CH_CAP_NAME: &str = "_partition_offsets_emitter_channel_capacity";
 const MET_CH_CAP_HELP: &str =
     "Capacity of internal channel used to send partition watermark offsets to rest of the service";
 

--- a/src/partition_offsets/lag_estimator.rs
+++ b/src/partition_offsets/lag_estimator.rs
@@ -227,6 +227,11 @@ impl PartitionLagEstimator {
         }
     }
 
+    /// How many [`TrackedOffset`] are stored.
+    pub fn usage(&self) -> usize {
+        self.latest_tracked_offsets.len()
+    }
+
     /// Given the constructor-time `capacity`, how much capacity is left spare, before
     /// a new [`PartitionLagEstimator::update()`] call will need to drop the earliest tracked?
     pub fn spare_capacity(&self) -> usize {

--- a/src/partition_offsets/mod.rs
+++ b/src/partition_offsets/mod.rs
@@ -33,8 +33,12 @@ pub fn init(
     let (po_rx, poe_join) =
         PartitionOffsetsEmitter::new(admin_client_config, cluster_status_register, metrics.clone())
             .spawn(shutdown_token);
-    let po_reg =
-        PartitionOffsetsRegister::new(po_rx, register_offsets_history, register_ready_at_pct, metrics);
+    let po_reg = PartitionOffsetsRegister::new(
+        po_rx,
+        register_offsets_history,
+        register_ready_at_pct,
+        metrics,
+    );
 
     debug!("Initialized");
     (po_reg, poe_join)

--- a/src/partition_offsets/mod.rs
+++ b/src/partition_offsets/mod.rs
@@ -12,6 +12,7 @@ pub use register::PartitionOffsetsRegister;
 pub use tracked_offset::TrackedOffset;
 
 // Imports
+use prometheus::Registry;
 use std::sync::Arc;
 
 use rdkafka::ClientConfig;
@@ -27,9 +28,10 @@ pub fn init(
     register_ready_at_pct: f64,
     cluster_status_register: Arc<ClusterStatusRegister>,
     shutdown_token: CancellationToken,
+    metrics: Arc<Registry>,
 ) -> (PartitionOffsetsRegister, JoinHandle<()>) {
     let (po_rx, poe_join) =
-        PartitionOffsetsEmitter::new(admin_client_config, cluster_status_register)
+        PartitionOffsetsEmitter::new(admin_client_config, cluster_status_register, metrics)
             .spawn(shutdown_token);
     let po_reg =
         PartitionOffsetsRegister::new(po_rx, register_offsets_history, register_ready_at_pct);

--- a/src/partition_offsets/mod.rs
+++ b/src/partition_offsets/mod.rs
@@ -31,10 +31,10 @@ pub fn init(
     metrics: Arc<Registry>,
 ) -> (PartitionOffsetsRegister, JoinHandle<()>) {
     let (po_rx, poe_join) =
-        PartitionOffsetsEmitter::new(admin_client_config, cluster_status_register, metrics)
+        PartitionOffsetsEmitter::new(admin_client_config, cluster_status_register, metrics.clone())
             .spawn(shutdown_token);
     let po_reg =
-        PartitionOffsetsRegister::new(po_rx, register_offsets_history, register_ready_at_pct);
+        PartitionOffsetsRegister::new(po_rx, register_offsets_history, register_ready_at_pct, metrics);
 
     debug!("Initialized");
     (po_reg, poe_join)

--- a/src/partition_offsets/register.rs
+++ b/src/partition_offsets/register.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
-use const_format::formatcp;
 use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
 use tokio::sync::{mpsc::Receiver, RwLock};
 
@@ -13,9 +12,9 @@ use super::lag_estimator::PartitionLagEstimator;
 use crate::internals::Awaitable;
 use crate::kafka_types::TopicPartition;
 use crate::partition_offsets::tracked_offset::TrackedOffset;
-use crate::prometheus_metrics::{LABEL_PARTITION, LABEL_TOPIC, NAMESPACE};
+use crate::prometheus_metrics::{LABEL_PARTITION, LABEL_TOPIC};
 
-const MET_USAGE_NAME: &str = formatcp!("{NAMESPACE}_partition_offsets_register_usage");
+const MET_USAGE_NAME: &str = "partition_offsets_register_usage";
 const MET_USAGE_HELP: &str = "Amount of offsets tracked per topic partition";
 
 /// Holds the offset of all Topic Partitions in the Kafka Cluster, and can estimate lag of Consumers.


### PR DESCRIPTION
Closes #57

Metrics added:

* `kmtd_partition_offsets_emitter_fetch_time_milliseconds`
* `kmtd_partition_offsets_emitter_channel_capacity`
* `kmtd_partition_offsets_register_usage`

Please see the `METRICS.md` file for details.