### PR TITLE
Get `ConsumerGroups` information from `ConsumerGroupRegister` and update tracked `Lag` when assigned consumer stops consuming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -97,7 +97,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -190,9 +190,9 @@ checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
-version = "3.15.0"
+version = "3.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a994c2b3ca201d9b263612a374263f05e7adde37c4707f693dcd375076d1f"
+checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytes"
@@ -211,12 +211,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 
 [[package]]
 name = "cfg-if"
@@ -235,7 +232,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -270,7 +267,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -471,9 +468,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
 
 [[package]]
 name = "http"
@@ -529,9 +526,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -543,6 +540,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
 ]
 
@@ -814,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -881,7 +879,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1073,29 +1071,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -1151,12 +1149,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1178,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.49"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1220,7 +1218,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1248,7 +1246,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -1300,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da193277a4e2c33e59e09b5861580c33dd0a637c3883d0fa74ba40c0374af2e"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.4.2",
  "bytes",
@@ -1398,7 +1396,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
  "wasm-bindgen-shared",
 ]
 
@@ -1420,7 +1418,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.49",
+ "syn 2.0.51",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1459,7 +1457,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1477,7 +1475,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1497,17 +1495,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -1518,9 +1516,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1530,9 +1528,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1542,9 +1540,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1554,9 +1552,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1566,9 +1564,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1578,9 +1576,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1590,9 +1588,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ const_format = "0.2.32"
 ctrlc = { version = "3.4.2", features = ["termination"] }
 env_logger = "0.11.2"
 exit-code = "1.0.0"
-hyper = { version = "1.1.0", features = ["http1", "http2", "server"] }
+hyper = { version = "1.2.0", features = ["http1", "http2", "server"] }
 konsumer_offsets = { version = "0.3.0", default-features = false, features = ["ts_chrono"] }
 log = "0.4.20"
 prometheus = "0.13.3"

--- a/src/cluster_status/emitter.rs
+++ b/src/cluster_status/emitter.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{any::type_name, sync::Arc};
 
 use prometheus::{
     register_histogram_with_registry, register_int_gauge_with_registry, Histogram, IntGauge,
@@ -146,7 +146,7 @@ impl Emitter for ClusterStatusEmitter {
                         tokio::select! {
                             res = Self::emit_with_interval(&sx, status, &mut interval) => {
                                 if let Err(e) = res {
-                                    error!("Failed to emit {}: {e}", std::any::type_name::<ClusterStatus>());
+                                    error!("Failed to emit {}: {e}", type_name::<ClusterStatus>());
                                 }
                             },
                             _ = shutdown_token.cancelled() => {

--- a/src/cluster_status/emitter.rs
+++ b/src/cluster_status/emitter.rs
@@ -89,13 +89,13 @@ impl ClusterStatusEmitter {
                 MET_FETCH_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_FETCH_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_FETCH_NAME}': {e}")),
             metric_ch_cap: register_int_gauge_with_registry!(
                 MET_CH_CAP_NAME,
                 MET_CH_CAP_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_CH_CAP_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_CH_CAP_NAME}': {e}")),
         }
     }
 }

--- a/src/cluster_status/mod.rs
+++ b/src/cluster_status/mod.rs
@@ -4,17 +4,16 @@ mod register;
 
 use std::sync::Arc;
 
-// Exports
-pub use emitter::ClusterStatusEmitter;
-pub use register::ClusterStatusRegister;
-
-// Imports
 use prometheus::Registry;
 use rdkafka::ClientConfig;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::internals::Emitter;
+use emitter::ClusterStatusEmitter;
+
+// Exports
+pub use register::ClusterStatusRegister;
 
 pub fn init(
     admin_client_config: ClientConfig,

--- a/src/cluster_status/register.rs
+++ b/src/cluster_status/register.rs
@@ -50,26 +50,28 @@ impl ClusterStatusRegister {
                 MET_BROKERS_TOT_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_BROKERS_TOT_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_BROKERS_TOT_NAME}': {e}")),
             metric_topics: register_int_gauge_with_registry!(
                 MET_TOPICS_TOT_NAME,
                 MET_TOPICS_TOT_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_TOPICS_TOT_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_TOPICS_TOT_NAME}': {e}")),
             metric_partitions: register_int_gauge_with_registry!(
                 MET_PARTITIONS_TOT_NAME,
                 MET_PARTITIONS_TOT_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_PARTITIONS_TOT_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_PARTITIONS_TOT_NAME}': {e}")),
             metric_topic_partitions: register_int_gauge_vec_with_registry!(
                 MET_TOPIC_PARTITIONS_TOT_NAME,
                 MET_TOPIC_PARTITIONS_TOT_HELP,
                 &[LABEL_TOPIC],
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_TOPIC_PARTITIONS_TOT_NAME}")),
+            .unwrap_or_else(|e| {
+                panic!("Failed to create metric '{MET_TOPIC_PARTITIONS_TOT_NAME}': {e}")
+            }),
         };
 
         // A clone of the `csr.latest_status` will be moved into the async task

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -20,10 +20,15 @@ pub(crate) const DEFAULT_HTTP_PORT: &str = "6564"; //< `u16` after parsing
 /// See [`crate::Cli`]'s `offsets_history`.
 pub(crate) const DEFAULT_OFFSETS_HISTORY: &str = "3600"; //< `usize` after parsing
 
-/// The default fullness percentage" at which the Partition Offset Register can be considered ready.
+/// The default fullness percentage at which the Partition Offset Register can be considered ready.
 ///
 /// See [`crate::Cli`]'s `offsets_history_ready_at`.
 pub(crate) const DEFAULT_OFFSETS_HISTORY_READY_AT: &str = "0.3"; //< `f64` after parsing
 
 /// The default `cluster_id` value, if none is provided (either via CLI override, nor Cluster configuration).
 pub(crate) const DEFAULT_CLUSTER_ID: &str = "__not-set__";
+
+/// The default duration after which a Consumer Group not reported anymore by Kafka, is forgotten.
+///
+/// See [`crate::Cli`]'s `duration_clap_value_parser`.
+pub(crate) const DEFAULT_FORGET_GROUP_AFTER_SECONDS: &str = "3600"; //< `Duration` after parsing

--- a/src/consumer_groups/emitter.rs
+++ b/src/consumer_groups/emitter.rs
@@ -1,4 +1,5 @@
 use std::{
+    any::type_name,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
@@ -185,7 +186,7 @@ impl Emitter for ConsumerGroupsEmitter {
                         tokio::select! {
                             res = Self::emit_with_interval(&sx, cg, &mut interval) => {
                                 if let Err(e) = res {
-                                    error!("Failed to emit {}: {e}", std::any::type_name::<ConsumerGroups>());
+                                    error!("Failed to emit {}: {e}", type_name::<ConsumerGroups>());
                                 }
                             },
                             _ = shutdown_token.cancelled() => {

--- a/src/consumer_groups/emitter.rs
+++ b/src/consumer_groups/emitter.rs
@@ -5,8 +5,8 @@ use std::{
 
 use konsumer_offsets::ConsumerProtocolAssignment;
 use prometheus::{
-    register_histogram_with_registry, register_int_gauge_vec_with_registry,
-    register_int_gauge_with_registry, Histogram, IntGauge, IntGaugeVec, Registry,
+    register_histogram_with_registry, register_int_gauge_with_registry, Histogram, IntGauge,
+    Registry,
 };
 use rdkafka::{admin::AdminClient, client::DefaultClientContext, groups::GroupList, ClientConfig};
 use tokio::{
@@ -19,17 +19,12 @@ use tokio_util::sync::CancellationToken;
 use crate::constants::KOMMITTED_CONSUMER_OFFSETS_CONSUMER;
 use crate::internals::Emitter;
 use crate::kafka_types::{Group, GroupWithMembers, Member, MemberWithAssignment, TopicPartition};
-use crate::prometheus_metrics::LABEL_GROUP;
 
 const CHANNEL_SIZE: usize = 5;
 
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 const FETCH_INTERVAL: Duration = Duration::from_secs(60);
 
-const MET_TOT_NAME: &str = "consumer_groups_total";
-const MET_TOT_HELP: &str = "Consumer groups currently in the cluster";
-const MET_MEMBERS_TOT_NAME: &str = "consumer_groups_members_total";
-const MET_MEMBERS_TOT_HELP: &str = "Members of consumer groups currently in the cluster";
 const MET_FETCH_NAME: &str = "consumer_groups_emitter_fetch_time_milliseconds";
 const MET_FETCH_HELP: &str =
     "Time (ms) taken to fetch information about all consumer groups in cluster";
@@ -115,8 +110,6 @@ pub struct ConsumerGroupsEmitter {
     admin_client_config: ClientConfig,
 
     // Prometheus Metrics
-    metric_tot: IntGauge,
-    metric_members_tot: IntGaugeVec,
     metric_fetch: Histogram,
     metric_ch_cap: IntGauge,
 }
@@ -130,27 +123,18 @@ impl ConsumerGroupsEmitter {
     pub fn new(admin_client_config: ClientConfig, metrics: Arc<Registry>) -> Self {
         Self {
             admin_client_config,
-            metric_tot: register_int_gauge_with_registry!(MET_TOT_NAME, MET_TOT_HELP, metrics)
-                .unwrap_or_else(|_| panic!("Failed to create metric: {MET_TOT_NAME}")),
-            metric_members_tot: register_int_gauge_vec_with_registry!(
-                MET_MEMBERS_TOT_NAME,
-                MET_MEMBERS_TOT_HELP,
-                &[LABEL_GROUP],
-                metrics
-            )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_MEMBERS_TOT_NAME}")),
             metric_fetch: register_histogram_with_registry!(
                 MET_FETCH_NAME,
                 MET_FETCH_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_FETCH_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_FETCH_NAME}': {e}")),
             metric_ch_cap: register_int_gauge_with_registry!(
                 MET_CH_CAP_NAME,
                 MET_CH_CAP_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_CH_CAP_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_CH_CAP_NAME}': {e}")),
         }
     }
 }
@@ -178,8 +162,6 @@ impl Emitter for ConsumerGroupsEmitter {
         let (sx, rx) = mpsc::channel::<Self::Emitted>(CHANNEL_SIZE);
 
         // Clone metrics so they can be used in the spawned future
-        let metric_cg = self.metric_tot.clone();
-        let metric_cg_members = self.metric_members_tot.clone();
         let metric_cg_fetch = self.metric_fetch.clone();
         let metric_cg_ch_cap = self.metric_ch_cap.clone();
 
@@ -197,11 +179,6 @@ impl Emitter for ConsumerGroupsEmitter {
 
                 match res_cg {
                     Ok(cg) => {
-                        // Update group and group member metrics
-                        metric_cg.set(cg.groups.len() as i64);
-                        for (g, gm) in cg.groups.iter() {
-                            metric_cg_members.with_label_values(&[&g]).set(gm.members.len() as i64);
-                        }
                         // Update channel capacity metric
                         metric_cg_ch_cap.set(sx.capacity() as i64);
 

--- a/src/consumer_groups/mod.rs
+++ b/src/consumer_groups/mod.rs
@@ -1,26 +1,33 @@
 // Inner module
 mod emitter;
+mod register;
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use prometheus::Registry;
 use rdkafka::ClientConfig;
-use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::internals::Emitter;
+use emitter::ConsumerGroupsEmitter;
 
-pub use emitter::{ConsumerGroups, ConsumerGroupsEmitter};
+// Exports
+pub use register::ConsumerGroupsRegister;
 
 pub fn init(
     admin_client_config: ClientConfig,
+    forget_after: Duration,
     shutdown_token: CancellationToken,
     metrics: Arc<Registry>,
-) -> (Receiver<ConsumerGroups>, JoinHandle<()>) {
-    let consumer_groups_emitter = ConsumerGroupsEmitter::new(admin_client_config, metrics);
-    let (cg_rx, cg_join) = consumer_groups_emitter.spawn(shutdown_token);
+) -> (ConsumerGroupsRegister, JoinHandle<()>) {
+    let forget_after = chrono::Duration::from_std(forget_after)
+        .unwrap_or_else(|e| panic!("Failed to convert from std::Duration: {e}"));
+
+    let (cg_rx, cg_join) =
+        ConsumerGroupsEmitter::new(admin_client_config, metrics.clone()).spawn(shutdown_token);
+    let cg_reg = ConsumerGroupsRegister::new(cg_rx, forget_after, metrics);
 
     debug!("Initialized");
-    (cg_rx, cg_join)
+    (cg_reg, cg_join)
 }

--- a/src/consumer_groups/mod.rs
+++ b/src/consumer_groups/mod.rs
@@ -21,9 +21,6 @@ pub fn init(
     shutdown_token: CancellationToken,
     metrics: Arc<Registry>,
 ) -> (ConsumerGroupsRegister, JoinHandle<()>) {
-    let forget_after = chrono::Duration::from_std(forget_after)
-        .unwrap_or_else(|e| panic!("Failed to convert from std::Duration: {e}"));
-
     let (cg_rx, cg_join) =
         ConsumerGroupsEmitter::new(admin_client_config, metrics.clone()).spawn(shutdown_token);
     let cg_reg = ConsumerGroupsRegister::new(cg_rx, forget_after, metrics);

--- a/src/consumer_groups/register.rs
+++ b/src/consumer_groups/register.rs
@@ -60,7 +60,19 @@ impl GroupWithMembersLastSeen {
     /// # Arguments
     /// * `expire_after` - Amount of time after which this group should be considered "expired".
     pub fn is_expired(&self, expire_after: &Duration) -> bool {
-        Utc::now() - self.last_seen > *expire_after
+        match chrono::Duration::from_std(*expire_after) {
+            Ok(expire_after_chrono) => {
+                let elapsed_ms = (Utc::now() - self.last_seen).num_milliseconds();
+                let expire_after_ms = expire_after_chrono.num_milliseconds();
+                elapsed_ms > expire_after_ms
+            },
+            Err(e) => {
+                warn!("Unable to convert Duration {:?} from std to chrono: {}", expire_after, e);
+                false
+            },
+        }
+    }
+}
     }
 }
 

--- a/src/consumer_groups/register.rs
+++ b/src/consumer_groups/register.rs
@@ -1,0 +1,204 @@
+use std::hash::{Hash, Hasher};
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    sync::Arc,
+};
+
+use chrono::{DateTime, Duration, Utc};
+use prometheus::{
+    register_int_gauge_vec_with_registry, register_int_gauge_with_registry, IntGauge, IntGaugeVec,
+    Registry,
+};
+use tokio::sync::{mpsc::Receiver, RwLock};
+
+use super::emitter::ConsumerGroups;
+
+use crate::internals::Awaitable;
+use crate::kafka_types::GroupWithMembers;
+use crate::prometheus_metrics::LABEL_GROUP;
+
+const MET_TOT_NAME: &str = "consumer_groups_total";
+const MET_TOT_HELP: &str = "Consumer groups currently in the cluster";
+const MET_MEMBERS_TOT_NAME: &str = "consumer_groups_members_total";
+const MET_MEMBERS_TOT_HELP: &str = "Members of consumer groups currently in the cluster";
+
+/// Contains a [`GroupWithMembers`] as well as when was the last time it was "seen".
+///
+/// In this case "seen" means that the Kafka Cluster knew of its existence.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GroupWithMembersLastSeen {
+    pub group_with_members: GroupWithMembers,
+    pub last_seen: DateTime<Utc>,
+}
+
+impl From<GroupWithMembers> for GroupWithMembersLastSeen {
+    /// Creates a [`Self`] and marks it as _last seen_ now (i.e. when method is invoked).
+    fn from(group_with_members: GroupWithMembers) -> Self {
+        GroupWithMembersLastSeen {
+            group_with_members,
+            last_seen: Utc::now(),
+        }
+    }
+}
+
+impl Hash for GroupWithMembersLastSeen {
+    /// [`Self`] implements [`Hash`] in a bespoke way,
+    /// as we need it to return the same value as the hashing of the contained [`GroupWithMembers`].
+    ///
+    /// This is desirable because as long as the contained [`GroupWithMembers`] doesn't change,
+    /// but it's "seen" during an update cycle, we don't want to alter the hash-value because
+    /// the internal `last_seen` gets updated every time.
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.group_with_members.hash(state);
+    }
+}
+
+impl GroupWithMembersLastSeen {
+    /// Returns `true` if this group is "expired".
+    /// If expired, this group should be "forgotten".
+    ///
+    /// # Arguments
+    /// * `expire_after` - Amount of time after which this group should be considered "expired".
+    pub fn is_expired(&self, expire_after: &Duration) -> bool {
+        Utc::now() - self.last_seen > *expire_after
+    }
+}
+
+/// Registers and exposes the latest, still known [`GroupWithMembersLastSeen`].
+///
+/// When the register is created, it's provided a `forget_after` [`Duration`].
+/// A Group that stops being reported/known by the Kafka Cluster, will be automatically
+/// removed ("forgotten") by this register, after `forget_after` time.
+///
+/// It exposes the accessor methods via an async interface,
+/// while dealing internally with concurrency and synchronization.
+#[derive(Debug)]
+pub struct ConsumerGroupsRegister {
+    /// Map ([`HashMap`]) of [`GroupWithMembersLastSeen`], paired with its own _hash_ value.
+    ///
+    /// The hash is calculated every time the map is updated, using [`DefaultHasher`].
+    known_groups: Arc<RwLock<(u64, HashMap<String, GroupWithMembersLastSeen>)>>,
+
+    /// Every time a new [`ConsumerGroups`] is received by this register,
+    /// [`GroupWithMembersLastSeen`] that were not "seen" for longer than this value,
+    /// are removed from the `known_groups` map.
+    forget_after: Duration,
+
+    // Prometheus Metrics
+    metric_tot: IntGauge,
+    metric_members_tot: IntGaugeVec,
+}
+
+impl ConsumerGroupsRegister {
+    pub fn new(
+        mut rx: Receiver<ConsumerGroups>,
+        forget_after: Duration,
+        metrics: Arc<Registry>,
+    ) -> Self {
+        let cgr = Self {
+            known_groups: Arc::new(RwLock::new((0u64, HashMap::new()))),
+            forget_after,
+            metric_tot: register_int_gauge_with_registry!(MET_TOT_NAME, MET_TOT_HELP, metrics)
+                .unwrap_or_else(|e| panic!("Failed to create metric '{MET_TOT_NAME}': {e}")),
+            metric_members_tot: register_int_gauge_vec_with_registry!(
+                MET_MEMBERS_TOT_NAME,
+                MET_MEMBERS_TOT_HELP,
+                &[LABEL_GROUP],
+                metrics
+            )
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_MEMBERS_TOT_NAME}': {e}")),
+        };
+
+        // A clone of the `cgr.known_groups` will be moved into the async task
+        // that updates the register.
+        let known_groups_arc_clone = cgr.known_groups.clone();
+
+        // Clone metrics so they can be used in the spawned future
+        let metric_tot = cgr.metric_tot.clone();
+        let metric_members_tot = cgr.metric_members_tot.clone();
+
+        // The Register is essentially "self updating" its data, by listening
+        // on a channel for updates.
+        //
+        // The internal async task will terminate when the internal loop breaks:
+        // that will happen when the `Receiver` `rx` receives `None`.
+        // And, in turn, that will happen when the `Sender` part of the channel is dropped.
+        tokio::spawn(async move {
+            debug!("Begin receiving ConsumerGroups updates");
+
+            loop {
+                tokio::select! {
+                    Some(cg) = rx.recv() => {
+                        trace!("Received:\n{:#?}", cg);
+
+                        // Update total metric
+                        metric_tot.set(cg.groups.len() as i64);
+
+                        // Update the `known_groups` and it's hash
+                        let mut w_guard = known_groups_arc_clone.write().await;
+                        for (g_name, g_members) in cg.groups.into_iter() {
+                            // Update group-specific metric
+                            metric_members_tot.with_label_values(&[&g_name]).set(g_members.members.len() as i64);
+
+                            // Upserting the map entry
+                            w_guard.1.insert(g_name, g_members.into());
+
+                            // Remove all the Groups that have expired
+                            // (i.e. excited the expected "forget after" duration)
+                            w_guard.1.retain(|_, g| !g.is_expired(&cgr.forget_after));
+
+                            // Calculate and update the hash
+                            let mut h = DefaultHasher::new();
+                            for (g, gm) in &w_guard.1 {
+                                g.hash(&mut h);
+                                gm.hash(&mut h);
+                            }
+                            w_guard.0 = h.finish();
+                        }
+                    },
+                    else => {
+                        info!("Emitters stopping: breaking (internal) loop");
+                        break;
+                    },
+                }
+
+                info!(
+                    "Updated (Known) Consumer Groups: {}",
+                    known_groups_arc_clone.read().await.1.len()
+                );
+            }
+        });
+
+        cgr
+    }
+
+    /// Returns [`Vec<String>`] with all the known Consumer Group identifiers.
+    pub async fn get_groups(&self) -> Vec<String> {
+        self.known_groups.read().await.1.keys().cloned().collect()
+    }
+
+    /// Returns a specific [`GroupWithMembers`], if found.
+    ///
+    /// # Arguments
+    /// * `group` - Consumer Group identifier (name)
+    pub async fn get_group(&self, group: &str) -> Option<GroupWithMembers> {
+        self.known_groups.read().await.1.get(group).map(|g| g.group_with_members.clone())
+    }
+
+    /// Returns a `u64` value representing the [`Hash`] of the current [`GroupWithMembers`] held in this register.
+    pub async fn get_hash(&self) -> u64 {
+        self.known_groups.read().await.0
+    }
+}
+
+impl Awaitable for ConsumerGroupsRegister {
+    /// [`Self`] ready when it's not empty.
+    async fn is_ready(&self) -> bool {
+        !self.known_groups.read().await.1.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO...
+}

--- a/src/consumer_groups/register.rs
+++ b/src/consumer_groups/register.rs
@@ -21,7 +21,7 @@ use crate::internals::Awaitable;
 use crate::kafka_types::GroupWithMembers;
 use crate::prometheus_metrics::LABEL_GROUP;
 
-const REMOVE_EXPIRED_INTERVAL: Duration = Duration::from_millis(500);
+const REMOVE_EXPIRED_INTERVAL: Duration = Duration::from_secs(1);
 
 const MET_TOT_NAME: &str = "consumer_groups_total";
 const MET_TOT_HELP: &str = "Consumer groups currently in the cluster";
@@ -193,9 +193,11 @@ impl ConsumerGroupsRegister {
                     },
                 }
 
-                info!(
-                    "Updated (Known) Consumer Groups: {}",
-                    known_groups_arc_clone.read().await.map.len()
+                let r_guard = known_groups_arc_clone.read().await;
+                trace!(
+                    "Updated (Known) Consumer Groups: {} (hash: {})",
+                    r_guard.map.len(),
+                    r_guard.hash,
                 );
             }
         });

--- a/src/internals/awaitable.rs
+++ b/src/internals/awaitable.rs
@@ -1,3 +1,5 @@
+use std::any::type_name;
+
 use thiserror::Error;
 use tokio::{time::interval, time::Duration};
 use tokio_util::sync::CancellationToken;
@@ -24,12 +26,12 @@ pub trait Awaitable {
             tokio::select! {
                 _ = interval.tick() => {
                     if self.is_ready().await {
-                        info!("{} is ready!", std::any::type_name::<Self>());
+                        info!("{} is ready!", type_name::<Self>());
                         return Ok(());
                     }
                 },
                 _ = shutdown_token.cancelled() => {
-                    warn!("{} received shutdown signal before it was ready!", std::any::type_name::<Self>());
+                    warn!("{} received shutdown signal before it was ready!", type_name::<Self>());
                     return Err(AwaitableError::Cancelled);
                 },
             }

--- a/src/internals/emitter.rs
+++ b/src/internals/emitter.rs
@@ -1,3 +1,5 @@
+use std::any::type_name;
+
 use tokio::{sync::mpsc, task::JoinHandle, time::Interval};
 use tokio_util::sync::CancellationToken;
 
@@ -48,7 +50,7 @@ pub trait Emitter {
         if sender.capacity() == 0 {
             trace!(
                 "Channel to emit {} saturated: receiver too slow or service still starting?",
-                std::any::type_name::<Self::Emitted>()
+                type_name::<Self::Emitted>()
             );
         }
 

--- a/src/kafka_types/group.rs
+++ b/src/kafka_types/group.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{Hash, Hasher},
+};
 
 use crate::kafka_types::TopicPartition;
 
@@ -25,8 +28,17 @@ pub struct MemberWithAssignment {
     pub assignment: HashSet<TopicPartition>,
 }
 
+impl Hash for MemberWithAssignment {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.member.hash(state);
+        for tp in &self.assignment {
+            tp.hash(state);
+        }
+    }
+}
+
 /// Consumer Group
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
 pub struct Group {
     /// Group name
     pub name: String,
@@ -46,4 +58,14 @@ pub struct Group {
 pub struct GroupWithMembers {
     pub group: Group,
     pub members: HashMap<String, MemberWithAssignment>,
+}
+
+impl Hash for GroupWithMembers {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.group.hash(state);
+        for (g, gm) in &self.members {
+            g.hash(state);
+            gm.hash(state);
+        }
+    }
 }

--- a/src/konsumer_offsets_data/emitter.rs
+++ b/src/konsumer_offsets_data/emitter.rs
@@ -1,9 +1,10 @@
+use std::any::type_name;
+
 use konsumer_offsets::KonsumerOffsetsData;
-use rdkafka::error::KafkaError;
 use rdkafka::{
     config::RDKafkaLogLevel,
     consumer::{Consumer, ConsumerContext, Rebalance, StreamConsumer},
-    error::KafkaResult,
+    error::{KafkaError, KafkaResult},
     ClientConfig, ClientContext, Message, Offset, TopicPartitionList,
 };
 use tokio::{sync::mpsc, task::JoinHandle, time::Duration};
@@ -167,7 +168,7 @@ impl Emitter for KonsumerOffsetsDataEmitter {
                                 match konsumer_offsets::KonsumerOffsetsData::try_from_bytes(m.key(), m.payload()) {
                                     Ok(kod) => {
                                         if let Err(e) = Self::emit(&sx, kod).await {
-                                            error!("Failed to emit {}: {e}", std::any::type_name::<KonsumerOffsetsData>());
+                                            error!("Failed to emit {}: {e}", type_name::<KonsumerOffsetsData>());
                                         }
                                     }
                                     Err(e) => {

--- a/src/konsumer_offsets_data/mod.rs
+++ b/src/konsumer_offsets_data/mod.rs
@@ -1,3 +1,4 @@
+// Inner module
 mod emitter;
 
 use konsumer_offsets::KonsumerOffsetsData;
@@ -8,6 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::internals::Emitter;
 
+// Exports
 pub use emitter::KonsumerOffsetsDataEmitter;
 
 pub fn init(

--- a/src/lag_register/mod.rs
+++ b/src/lag_register/mod.rs
@@ -1,3 +1,4 @@
+// Inner module
 mod register;
 
 use std::sync::Arc;
@@ -5,17 +6,17 @@ use std::sync::Arc;
 use konsumer_offsets::KonsumerOffsetsData;
 use tokio::sync::mpsc::Receiver;
 
-use crate::consumer_groups::ConsumerGroups;
+use crate::consumer_groups::ConsumerGroupsRegister;
 use crate::partition_offsets::PartitionOffsetsRegister;
 
 pub use register::{Lag, LagRegister};
 
 pub fn init(
-    cg_rx: Receiver<ConsumerGroups>,
     kod_rx: Receiver<KonsumerOffsetsData>,
+    cg_reg: Arc<ConsumerGroupsRegister>,
     po_reg: Arc<PartitionOffsetsRegister>,
 ) -> LagRegister {
-    let l_reg = LagRegister::new(cg_rx, kod_rx, po_reg);
+    let l_reg = LagRegister::new(kod_rx, cg_reg, po_reg);
 
     debug!("Initialized");
     l_reg

--- a/src/lag_register/register.rs
+++ b/src/lag_register/register.rs
@@ -209,7 +209,7 @@ async fn process_consumer_groups(
     }
 
     // ... then, remove groups that are in `lag_register_groups` but are not known (anymore)
-    lag_register_groups.write().await.retain(|g, _| !known_groups.contains(g));
+    lag_register_groups.write().await.retain(|g, _| known_groups.contains(g));
 }
 
 async fn process_offset_commit(

--- a/src/partition_offsets/emitter.rs
+++ b/src/partition_offsets/emitter.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{any::type_name, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use prometheus::{
@@ -149,7 +149,7 @@ impl Emitter for PartitionOffsetsEmitter {
                                 tokio::select! {
                                     res = Self::emit(&sx, po) => {
                                         if let Err(e) = res {
-                                            error!("Failed to emit {}: {e}", std::any::type_name::<PartitionOffset>());
+                                            error!("Failed to emit {}: {e}", type_name::<PartitionOffset>());
                                         }
                                     },
                                     _ = shutdown_token.cancelled() => {

--- a/src/partition_offsets/emitter.rs
+++ b/src/partition_offsets/emitter.rs
@@ -80,13 +80,13 @@ impl PartitionOffsetsEmitter {
                 &[LABEL_TOPIC, LABEL_PARTITION],
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_FETCH_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_FETCH_NAME}': {e}")),
             metric_ch_cap: register_int_gauge_with_registry!(
                 MET_CH_CAP_NAME,
                 MET_CH_CAP_HELP,
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_CH_CAP_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_CH_CAP_NAME}': {e}")),
         }
     }
 }

--- a/src/partition_offsets/lag_estimator.rs
+++ b/src/partition_offsets/lag_estimator.rs
@@ -351,7 +351,7 @@ mod test {
     }
 
     #[test]
-    fn test_interpolate_offset_to_datetime() {
+    fn should_interpolate_offset_to_datetime() {
         let (off, ts) = example_tracked_offsets();
 
         let p1 = TrackedOffset {
@@ -377,7 +377,7 @@ mod test {
     }
 
     #[test]
-    fn estimate_offset_lag() {
+    fn should_estimate_offset_lag() {
         let (off, ts) = example_tracked_offsets();
 
         // Setup estimator with example input
@@ -399,7 +399,7 @@ mod test {
     }
 
     #[test]
-    fn should_ignore_updates_that_tracked_datapoints() {
+    fn should_ignore_updates_for_already_tracked_offsets() {
         let (off, ts) = example_tracked_offsets();
 
         // Setup estimator with example input
@@ -416,7 +416,7 @@ mod test {
     }
 
     #[test]
-    fn estimate_time_lag() {
+    fn should_estimate_time_lag() {
         let (off, ts) = example_tracked_offsets();
 
         // Setup estimator with example input
@@ -444,7 +444,7 @@ mod test {
     }
 
     #[test]
-    fn discard_old_tracked_offsets() {
+    fn should_discard_old_tracked_offsets() {
         let mut estimator = PartitionLagEstimator::new(5);
 
         // Add first 5 points
@@ -491,7 +491,7 @@ mod test {
     }
 
     #[test]
-    fn use_percent() {
+    fn should_provide_usage_percent() {
         let (off, ts) = example_tracked_offsets();
 
         let mut estimator = PartitionLagEstimator::new(10);

--- a/src/partition_offsets/lag_estimator.rs
+++ b/src/partition_offsets/lag_estimator.rs
@@ -156,17 +156,26 @@ impl PartitionLagEstimator {
     /// Extrapolates the given consumer group offset and related read date time for this partition,
     /// a returns a [`Duration`] estimation of the time lag accumulated by the consumer group.
     ///
+    /// What is measured is the difference of time between when the give `offset` was produced
+    /// (estimated), and how far behind in time is the Consumer, if it consumed it right now.
+    ///
     /// This estimation is done by a linear interpolation/extrapolation, where the fixed points
     /// are the [`TrackedOffset`]s contained in the [`PartitionLagEstimator`] at the time of call.
+    ///
+    /// When a Consumer stops committing offsets (i.e. stalls, fails, crashes...), time does
+    /// keep moving forward. And, in normal circumstances, producers are still writing to the partition.
+    /// This method can be used to estimate a moving-lag: the consumer stopped but the partition
+    /// is still being written to. The way to do it, is to provide as arguments the last known
+    /// Consumer-committed offset, and the latest produced offset timestamp.
     ///
     /// # Arguments
     ///
     /// * `offset` - Given offset we want to compare against the latest tracked offset
-    /// * `offset_datetime` - The [`DateTime<Utc>`] this offset was committed
+    /// * `offset_at` - [`DateTime<Utc>`] at which the latest consumed `offset` is know to be at
     pub fn estimate_time_lag(
         &self,
         offset: u64,
-        offset_datetime: DateTime<Utc>,
+        offset_at: DateTime<Utc>,
     ) -> PartitionOffsetsResult<Duration> {
         // It's rare, but if we happen to receive a consumed offset that is ahead of the last
         // tracked end offset, we can just return a Duration of `0` for time lag.
@@ -195,11 +204,11 @@ impl PartitionLagEstimator {
                 let latest_tracked = self.latest_tracked_offset()?;
                 let second_latest_tracked = self.nth_latest_tracked_offset(2)?;
 
-                // Estimate production time, considering widest range possible: earliest and latest tracked
+                // Estimate production time, considering the widest range possible: earliest and latest tracked
                 let widest_estimate =
                     interpolate_offset_to_datetime(earliest_tracked, latest_tracked, offset)?;
 
-                // Estimate production time, considering narrowest range possible: 2nd-latest and latest tracked
+                // Estimate production time, considering the narrowest range possible: 2nd-latest and latest tracked
                 let narrowest_estimate =
                     interpolate_offset_to_datetime(second_latest_tracked, latest_tracked, offset)?;
 
@@ -217,13 +226,13 @@ impl PartitionLagEstimator {
         //
         // While it's not possible for an offset to be consumed before it's produced (obviously),
         // it can happen that the linear interpolation done above, estimates the production time
-        // to be later then it ACTUALLY was.
+        // to be later than it ACTUALLY was.
         //
         // When that happen, is perfectly ok to consider the time lag to be EFFECTIVELY zero.
-        if offset_datetime < estimated_produced_offset_datetime {
+        if offset_at < estimated_produced_offset_datetime {
             Ok(Duration::zero())
         } else {
-            Ok(offset_datetime - estimated_produced_offset_datetime)
+            Ok(offset_at - estimated_produced_offset_datetime)
         }
     }
 

--- a/src/partition_offsets/mod.rs
+++ b/src/partition_offsets/mod.rs
@@ -5,20 +5,19 @@ mod lag_estimator;
 mod register;
 mod tracked_offset;
 
-// Exports
-pub use emitter::PartitionOffsetsEmitter;
-pub use register::PartitionOffsetsRegister;
-
-// Imports
-use prometheus::Registry;
 use std::sync::Arc;
 
+use prometheus::Registry;
 use rdkafka::ClientConfig;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::cluster_status::ClusterStatusRegister;
 use crate::internals::Emitter;
+use emitter::PartitionOffsetsEmitter;
+
+// Exports
+pub use register::PartitionOffsetsRegister;
 
 pub fn init(
     admin_client_config: ClientConfig,

--- a/src/partition_offsets/register.rs
+++ b/src/partition_offsets/register.rs
@@ -54,7 +54,7 @@ impl PartitionOffsetsRegister {
                 &[LABEL_TOPIC, LABEL_PARTITION],
                 metrics
             )
-            .unwrap_or_else(|_| panic!("Failed to create metric: {MET_USAGE_NAME}")),
+            .unwrap_or_else(|e| panic!("Failed to create metric '{MET_USAGE_NAME}': {e}")),
         };
 
         // A clone of the `por.estimator` will be moved into the async task

--- a/src/partition_offsets/register.rs
+++ b/src/partition_offsets/register.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{any::type_name, collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Duration, Utc};
 use prometheus::{register_int_gauge_vec_with_registry, IntGaugeVec, Registry};
@@ -99,7 +99,7 @@ impl PartitionOffsetsRegister {
                         // Get exclusive write lock on the specific partition esimator
                         let estimator_rwlock = r_guard
                             .get(&k)
-                            .unwrap_or_else(|| panic!("{} for {:#?} could not be found (fatal)", std::any::type_name::<PartitionLagEstimator>(), k));
+                            .unwrap_or_else(|| panic!("{} for {:#?} could not be found (fatal)", type_name::<PartitionLagEstimator>(), k));
 
                         // Update the PartitionLagEstimator
                         estimator_rwlock

--- a/src/partition_offsets/tracked_offset.rs
+++ b/src/partition_offsets/tracked_offset.rs
@@ -153,7 +153,7 @@ mod test {
     }
 
     #[test]
-    fn search_even_input() {
+    fn should_find_within_even_input() {
         let input = build_even_input();
 
         assert!(matches!(search(0, &input), TrackedOffsetSearchRes::None));
@@ -216,7 +216,7 @@ mod test {
     }
 
     #[test]
-    fn search_odd_input() {
+    fn should_find_within_odd_input() {
         let input = build_odd_input();
 
         assert!(matches!(search(0, &input), TrackedOffsetSearchRes::None));


### PR DESCRIPTION
Enables: #114

Here I introduce the `ConsumerGroupRegister`.

This is not too different from other `*Register`, like `ClusterStatusRegister`: its focus is on holding the information about the available, active `ConsumerGroups` in the cluster.

In addition to caching the information about `ConsumerGroups`, it enacts the role of "remembering the group for a certain amount of time": this is embodied in the `--forget-group-after` new command line parameter. This new register is going to not remove any of the `ConsumerGroups` that stop being reported by the cluster, for a fixed amount of time.

This is to help with the fact that, in case of an outage, a `Group` could disappear for various reasons (a crash?): if the `Group` was immediately _forgotten_, it would make the metric produced by Kommitted disappear.

This way the metric will keep being produced, and the internal estimator will use the known previous data points to estimating the growth of latency (that is ultimately the whole point of this service).

Additionally, this change allows for #114 to happen: to calculate lag for clusters hosted on Confluent Cloud, we need to refactor how the `KommittedOffsetsData` is produced, by allowing for an alternative `KommittedOffsetsDataEmitter` to be created (e.g. `ConfluentCloudOffsetsDataEmitter`). The API offered by Committed Offsets require a prior knowledge of the available groups, so the register here will work as a source of truth, for when the API calls are done to get to the offset information of the specific group.

The `main.rs` will have to then swap the default `KommittedOffsetsDataEmitter` with the `ConfluentCloudOffsetsDataEmitter`, based on input. But this is for a follow up PR.

