### PR TITLE
Update README to refer to --kafka-conf instead of --config

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ each argument can do.
     -b, --brokers <BOOTSTRAP_BROKERS>
             Initial Kafka Brokers to connect to (format: 'HOST:PORT,...').
   
-            Equivalent to '--config=bootstrap.servers:host:port,...'.
+            Equivalent to '--kafka-conf bootstrap.servers:host:port,...'.
   
         --client-id <CLIENT_ID>
             Client identifier used by the internal Kafka (Admin) Client.
   
-            Equivalent to '--config=client.id:my-client-id'.
+            Equivalent to '--kafka-conf client.id:my-client-id'.
   
             [default: kommitted]
   
@@ -192,16 +192,16 @@ each argument can do.
 ```shell
 $ kommitted \
     --brokers {{ BOOTSTRAP_BROKERS or BROKER_ENDPOINT }} \
-    --config security.protocol:SASL_SSL \
-    --config sasl.mechanisms=PLAIN \
-    --config sasl.username:{{ USERNAME or API_KEY }} \
-    --config sasl.password:{{ PASSWORD or API_SECRET }} \  
+    --kafka-conf security.protocol:SASL_SSL \
+    --kafka-conf sasl.mechanisms=PLAIN \
+    --kafka-conf sasl.username:{{ USERNAME or API_KEY }} \
+    --kafka-conf sasl.password:{{ PASSWORD or API_SECRET }} \
     ...
 ```
 
 ### Log verbosity
 
-Kommitted follows the long tradition of `-v/-q` to control the verbosity of it's logging:
+Kommitted follows the long tradition of `-v/-q` to control the verbosity of its logging:
 
 | Arguments | Log verbosity level | Default |
 |----------:|:--------------------|:-------:|

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,13 +21,13 @@ pub struct Cli {
     // ------------------------------------------------------------------ Admin Client configuration
     /// Initial Kafka Brokers to connect to (format: 'HOST:PORT,...').
     ///
-    /// Equivalent to '--config=bootstrap.servers:host:port,...'.
+    /// Equivalent to '--kafka-conf bootstrap.servers:host:port,...'.
     #[arg(short, long = "brokers", value_name = "BOOTSTRAP_BROKERS")]
     pub bootstrap_brokers: String,
 
     /// Client identifier used by the internal Kafka (Admin) Client.
     ///
-    /// Equivalent to '--config=client.id:my-client-id'.
+    /// Equivalent to '--kafka-conf client.id:my-client-id'.
     #[arg(long = "client-id", value_name = "CLIENT_ID", default_value = env!("CARGO_PKG_NAME"))]
     pub client_id: String,
 


### PR DESCRIPTION
Hi, thanks for sharing **kommitted**.  

I noticed that the README and the `--help` output refer to `--config`, but that option is not (or no longer) supported and results in this error message:

```
error: unexpected argument '--config' found
```

This PR updates references to `--config` to be `--kafka-conf`.